### PR TITLE
Fix error reporting when no JSON is returned by webservice

### DIFF
--- a/uploadToMetaboLightsLabs.py
+++ b/uploadToMetaboLightsLabs.py
@@ -153,7 +153,13 @@ def requestUploadConfiguration():
         logging.error(e)
         print "Request failed! Refer to the log file for more details"
         sys.exit(1)
-    return json.loads(response.text)['content']
+    try:
+        response_json = json.loads(response.text)['content']
+    except ValueError as e:
+        logging.error(e)
+        print('Could not decode response from server!')
+        sys.exit(1)
+    return response_json
 
 
 def parseInput(args):


### PR DESCRIPTION
Fix reporting when something other than JSON is returned by MetaboLights Labs webservice.

Reported via PhenoMeNal Slack https://phenomenal-h2020.slack.com/archives/CAP47SAF6/p1533632706000212